### PR TITLE
docs(readme): update instructions for brew on Mac

### DIFF
--- a/examples/cloud-in-a-box/README.md
+++ b/examples/cloud-in-a-box/README.md
@@ -5,7 +5,7 @@ It can serve as a local playground, starting point for local application develop
 
 Also, **_everything_** runs in containers, so you only need the usual [3musketeers setup](../../README.md) to use this example!
 
-**Note:** This guide assumes you have v2 of `docker compose` available (not the deprecated python `docker-compose` binary). If you are _not_ using Docker Desktop, you may need to create a symlink for Docker to find the plugin, e.g.:
+**Note:** This guide assumes you have v2 of `docker compose` available (not the deprecated python `docker-compose` package). If you are _not_ using Docker Desktop, you may need to create a symlink for Docker to find the plugin, e.g.:
 ```
 mkdir -p ~/.docker/cli-plugins
 ln -sfn $HOMEBREW_PREFIX/opt/docker-compose/bin/docker-compose ~/.docker/cli-plugins/docker-compose

--- a/examples/cloud-in-a-box/README.md
+++ b/examples/cloud-in-a-box/README.md
@@ -5,6 +5,12 @@ It can serve as a local playground, starting point for local application develop
 
 Also, **_everything_** runs in containers, so you only need the usual [3musketeers setup](../../README.md) to use this example!
 
+**Note:** This guide assumes you have v2 of `docker compose` available (not the deprecated python `docker-compose` binary). If you are _not_ using Docker Desktop, you may need to create a symlink for Docker to find the plugin, e.g.:
+```
+mkdir -p ~/.docker/cli-plugins
+ln -sfn $HOMEBREW_PREFIX/opt/docker-compose/bin/docker-compose ~/.docker/cli-plugins/docker-compose
+```
+
 ## Guide
 This guide walks you through the creation of a local Kubernetes cluster and sample app deployment.
 

--- a/examples/cloud-in-a-box/docker-compose.yaml
+++ b/examples/cloud-in-a-box/docker-compose.yaml
@@ -13,6 +13,7 @@ services:
     volumes:
       - .:/var/opt/app
     working_dir: /var/opt/app
+    user: "502:20"
   aws:
     networks:
       - localstack

--- a/examples/cloud-in-a-box/docker-compose.yaml
+++ b/examples/cloud-in-a-box/docker-compose.yaml
@@ -13,7 +13,6 @@ services:
     volumes:
       - .:/var/opt/app
     working_dir: /var/opt/app
-    user: "502:20"
   aws:
     networks:
       - localstack


### PR DESCRIPTION
When not using Docker Desktop the subcommand `compose` isn't available